### PR TITLE
Fixed deprecation warning with rails 2.3.8

### DIFF
--- a/lib/commentable_methods.rb
+++ b/lib/commentable_methods.rb
@@ -1,4 +1,4 @@
-require 'activerecord'
+require 'active_record'
 
 # ActsAsCommentable
 module Juixe

--- a/tasks/acts_as_commentable_tasks.rake
+++ b/tasks/acts_as_commentable_tasks.rake
@@ -1,4 +1,0 @@
-# desc "Explaining what the task does"
-# task :acts_as_commentable do
-#   # Task goes here
-# end


### PR DESCRIPTION
Rake was saying acts_as_commentable/tasks was deprecated. I moved it inside lib/
