### PR TITLE
multiple comments for a model not available on 3.0.1 version

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -58,6 +58,8 @@ Add multiple type of comments to a model:
     acts_as_commentable :public, :private
   end
 
+*Note:* This feature is only available from version 4.0 and above
+
 Fetch comments for a this model:
 
   public_comments = Todo.find(1).public_comments


### PR DESCRIPTION
I have added a comment on the readme. I have seen the issue https://github.com/jackdempsey/acts_as_commentable/issues/23 and I don't understand why the 4 version does not work on Rails 3.

I am using it right now on Rails 3.2, I don't see the issue
