### PR TITLE
Fix recent scope sorting problem

### DIFF
--- a/lib/comment_methods.rb
+++ b/lib/comment_methods.rb
@@ -10,7 +10,7 @@ module ActsAsCommentable
     def self.included(comment_model)
       comment_model.extend Finders
       comment_model.scope :in_order, -> { comment_model.order('created_at ASC') }
-      comment_model.scope :recent, -> { comment_model.order('created_at DESC') }
+      comment_model.scope :recent, -> { comment_model.reorder('created_at DESC') }
     end
 
     def is_comment_type?(type)

--- a/test/acts_as_commentable_test.rb
+++ b/test/acts_as_commentable_test.rb
@@ -121,6 +121,22 @@ class ActsAsCommentableTest < Test::Unit::TestCase
     assert_equal [public_comment, public_comment2], wall.public_comments_ordered_by_submitted
   end
 
+  def test_comments_ordered_by_submitted
+    post = Post.create(:text => "Awesome post !")
+    comment = post.comments.create(:title => "First comment.", :comment => "This is the first comment.")
+    comment2 = post.comments.create(:title => "Second comment.", :comment => "This is the second comment.")
+    assert_equal [comment2, comment], post.comments.recent
+
+    wall = Wall.create(:name => "wall")
+    private_comment = wall.private_comments.create(:title => "wall private comment", :comment => "Yipiyayeah !")
+    private_comment2 = wall.private_comments.create(:title => "wall private comment", :comment => "Yipiyayeah !")
+    assert_equal [private_comment2, private_comment], wall.private_comments.recent
+
+    public_comment = wall.public_comments.create(:title => "wall public comment", :comment => "Yipiyayeah !")
+    public_comment2 = wall.public_comments.create(:title => "wall public comment", :comment => "Yipiyayeah !")
+    assert_equal [public_comment2, public_comment], wall.public_comments.recent
+  end
+
   def test_add_comment
     post = Post.create(:text => "Awesome post !")
     comment = Comment.new(:title => "First Comment", :comment => 'Super comment')


### PR DESCRIPTION
The method _recent_ does not replace the default_scope defined on the model. That's why I replaced it by reorder.

See Issue #22
