### PR TITLE
The gem activerecord-depre... has a new name

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 group :development do
   gem 'rails', :git => 'git://github.com/rails/rails.git'
   # https://github.com/rails/rails/issues/6039
-  gem 'active_record_deprecated_finders', git: 'git://github.com/rails/active_record_deprecated_finders.git'
+  gem 'activerecord-deprecated_finders', git: 'git://github.com/rails/activerecord-deprecated_finders.git'
   gem 'sqlite3'
   gem 'pry'
 end


### PR DESCRIPTION
The gem activerecord-deprecated_finders has a new name:

See https://github.com/rails/activerecord-deprecated_finders/commit/d54b09e9f0c597ffb540f94cddb117b60e3d2672
