### PR TITLE
enable scope for all_comments when using roles

### DIFF
--- a/lib/commentable_methods.rb
+++ b/lib/commentable_methods.rb
@@ -27,6 +27,7 @@ module Juixe
                   :conditions => ["role = ?", role.to_s],
                   :before_add => Proc.new { |x, c| c.role = role.to_s }}
             end
+            has_many :all_comments, {:as => :commentable, :dependent => :destroy, class_name: "Comment"}
           else
             has_many :comments, {:as => :commentable, :dependent => :destroy}
           end


### PR DESCRIPTION
Useful when building admin panels and wish to list all comments (public/private)
