### PR TITLE
Remove nonexistent .rake file from gemspec

### DIFF
--- a/acts_as_commentable.gemspec
+++ b/acts_as_commentable.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.description = %q{Plugin/gem that provides comment functionality}
   s.email = %q{unknown@juixe.com}
   s.extra_rdoc_files = ["README.rdoc", "MIT-LICENSE"]
-  s.files = ["MIT-LICENSE", "README.rdoc", "lib/acts_as_commentable.rb", "lib/comment_methods.rb", "lib/commentable_methods.rb", "lib/generators", "lib/generators/comment", "lib/generators/comment/comment_generator.rb", "lib/generators/comment/templates", "lib/generators/comment/templates/comment.rb", "lib/generators/comment/templates/create_comments.rb", "lib/generators/comment/USEGA", "tasks/acts_as_commentable_tasks.rake", "init.rb", "install.rb"]
+  s.files = ["MIT-LICENSE", "README.rdoc", "lib/acts_as_commentable.rb", "lib/comment_methods.rb", "lib/commentable_methods.rb", "lib/generators", "lib/generators/comment", "lib/generators/comment/comment_generator.rb", "lib/generators/comment/templates", "lib/generators/comment/templates/comment.rb", "lib/generators/comment/templates/create_comments.rb", "lib/generators/comment/USEGA", "init.rb", "install.rb"]
   s.has_rdoc = false
   s.homepage = %q{http://www.juixe.com/techknow/index.php/2006/06/18/acts-as-commentable-plugin/}
   s.require_paths = ["lib"]


### PR DESCRIPTION
Fixes warning while bundling gems:

```
acts_as_commentable at /home/sergey/.rvm/gems/ruby-2.0.0-p0/bundler/gems/acts_as_commentable-    a637277ce9b4 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["tasks/acts_as_commentable_tasks.rake"] are not files
```
