### PR TITLE
Specify the Active Record version in the Gemspec file.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@ source 'http://rubygems.org'
 gemspec
 
 group :development do
-  gem 'rails', :git => 'git://github.com/rails/rails.git', :branch => '4-0-stable'
-  # https://github.com/rails/rails/issues/6039
-  gem 'activerecord-deprecated_finders', git: 'git://github.com/rails/activerecord-deprecated_finders.git'
   gem 'sqlite3'
   gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,108 +1,49 @@
-GIT
-  remote: git://github.com/rails/activerecord-deprecated_finders.git
-  revision: 86b8d3babecc30f3f3c9a2d937e3e845555b254a
+PATH
+  remote: .
   specs:
-    activerecord-deprecated_finders (1.0.3)
+    acts_as_commentable (4.0.1)
+      activerecord (>= 4.0.0)
 
-GIT
-  remote: git://github.com/rails/rails.git
-  revision: e2840596ad299a3eb83d0494cb3d2d1a1dd9e454
-  branch: 4-0-stable
+GEM
+  remote: http://rubygems.org/
   specs:
-    actionmailer (4.0.0)
-      actionpack (= 4.0.0)
-      mail (~> 2.5.4)
-    actionpack (4.0.0)
-      activesupport (= 4.0.0)
+    activemodel (4.0.2)
+      activesupport (= 4.0.2)
       builder (~> 3.1.0)
-      erubis (~> 2.7.0)
-      rack (~> 1.5.2)
-      rack-test (~> 0.6.2)
-    activemodel (4.0.0)
-      activesupport (= 4.0.0)
-      builder (~> 3.1.0)
-    activerecord (4.0.0)
-      activemodel (= 4.0.0)
+    activerecord (4.0.2)
+      activemodel (= 4.0.2)
       activerecord-deprecated_finders (~> 1.0.2)
-      activesupport (= 4.0.0)
+      activesupport (= 4.0.2)
       arel (~> 4.0.0)
-    activesupport (4.0.0)
+    activerecord-deprecated_finders (1.0.3)
+    activesupport (4.0.2)
       i18n (~> 0.6, >= 0.6.4)
       minitest (~> 4.2)
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
-    rails (4.0.0)
-      actionmailer (= 4.0.0)
-      actionpack (= 4.0.0)
-      activerecord (= 4.0.0)
-      activesupport (= 4.0.0)
-      bundler (>= 1.3.0, < 2.0)
-      railties (= 4.0.0)
-      sprockets-rails (~> 2.0.0)
-    railties (4.0.0)
-      actionpack (= 4.0.0)
-      activesupport (= 4.0.0)
-      rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
-
-PATH
-  remote: .
-  specs:
-    acts_as_commentable (4.0.0)
-
-GEM
-  remote: http://rubygems.org/
-  specs:
-    arel (4.0.0)
+    arel (4.0.2)
     atomic (1.1.14)
     builder (3.1.4)
     coderay (1.0.7)
-    erubis (2.7.0)
-    hike (1.2.3)
-    i18n (0.6.5)
-    mail (2.5.4)
-      mime-types (~> 1.16)
-      treetop (~> 1.4.8)
+    i18n (0.6.9)
     method_source (0.7.1)
-    mime-types (1.25)
     minitest (4.7.5)
-    multi_json (1.8.0)
-    polyglot (0.3.3)
+    multi_json (1.8.4)
     pry (0.9.9.6)
       coderay (~> 1.0.5)
       method_source (~> 0.7.1)
       slop (>= 2.4.4, < 3)
-    rack (1.5.2)
-    rack-test (0.6.2)
-      rack (>= 1.0)
-    rake (10.1.0)
     slop (2.4.4)
-    sprockets (2.10.0)
-      hike (~> 1.2)
-      multi_json (~> 1.0)
-      rack (~> 1.0)
-      tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.0.0)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (~> 2.8)
     sqlite3 (1.3.6)
-    thor (0.18.1)
     thread_safe (0.1.3)
       atomic
-    tilt (1.4.1)
-    treetop (1.4.15)
-      polyglot
-      polyglot (>= 0.3.1)
-    tzinfo (0.3.37)
+    tzinfo (0.3.38)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord-deprecated_finders!
   acts_as_commentable!
   pry
-  rails!
   sqlite3

--- a/acts_as_commentable.gemspec
+++ b/acts_as_commentable.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.6}
   s.summary = %q{Plugin/gem that provides comment functionality}
+  s.add_dependency "activerecord", ">= 4.0.0"
 
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION

--- a/lib/commentable_methods.rb
+++ b/lib/commentable_methods.rb
@@ -12,7 +12,7 @@ module Juixe
       module HelperMethods
         private
         def define_role_based_inflection(role)
-          send("define_role_based_inflection_#{Rails.version.first}", role)
+          send("define_role_based_inflection_#{ActiveRecord::VERSION::MAJOR}", role)
         end
 
         def define_role_based_inflection_3(role)


### PR DESCRIPTION
This allows bundler to resolve version dependencies correctly.
Also, rails has been removed as a development dependency, since
activerecord will suffice.
