### PR TITLE
Fix rubocop violations in generated comment.rb

### DIFF
--- a/lib/generators/comment/templates/comment.rb
+++ b/lib/generators/comment/templates/comment.rb
@@ -1,14 +1,13 @@
 class Comment < ActiveRecord::Base
-
   include ActsAsCommentable::Comment
 
-  belongs_to :commentable, :polymorphic => true
+  belongs_to :commentable, polymorphic: true
 
-  default_scope -> { order('created_at ASC') }
+  default_scope { order('created_at ASC')
 
   # NOTE: install the acts_as_votable plugin if you
   # want user to vote on the quality of comments.
-  #acts_as_votable
+  # acts_as_votable
 
   # NOTE: Comments belong to a user
   belongs_to :user


### PR DESCRIPTION
- Remove extraneous space after class declaration
- Use Ruby 1.9+ hash syntax (since Rails 4+ requires Ruby 1.9+ anyway)
- [default_scope expects a block, not a proc](https://github.com/bbatsov/rubocop/blob/master/lib/rubocop/cop/rails/default_scope.rb)
- Add space after #

Previous rubocop output:

```
Offenses:

app/models/comment.rb:2:1: C: Extra empty line detected at class body beginning.
app/models/comment.rb:5:28: C: Use the new Ruby 1.9 hash syntax.
  belongs_to :commentable, :polymorphic => true
                           ^^^^^^^^^^^^^^^
app/models/comment.rb:7:17: C: default_scope expects a block as its sole argument.
  default_scope -> { order('created_at ASC') }
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
app/models/comment.rb:11:3: C: Missing space after #.
  #acts_as_voteable
  ^^^^^^^^^^^^^^^^^
```
