### PR TITLE
Add license to gemspec

### DIFF
--- a/acts_as_commentable.gemspec
+++ b/acts_as_commentable.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.6}
   s.summary = %q{Plugin/gem that provides comment functionality}
+  s.license = 'MIT'
 
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION


### PR DESCRIPTION
I was trying to determine the licenses for my dependencies. I found that the RubyGems API will return the license, but only if it is specified in your gemspec file.