### PR TITLE
Refactored Juixe::Acts::Commentable a bit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :development do
   gem 'activerecord-deprecated_finders', git: 'git://github.com/rails/activerecord-deprecated_finders.git'
   gem 'sqlite3'
   gem 'pry'
+  gem 'test-unit'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,7 +49,7 @@ GIT
 PATH
   remote: .
   specs:
-    acts_as_commentable (4.0.1)
+    acts_as_commentable (4.0.2)
 
 GEM
   remote: http://rubygems.org/
@@ -88,6 +88,7 @@ GEM
       activesupport (>= 3.0)
       sprockets (~> 2.8)
     sqlite3 (1.3.6)
+    test-unit (2.1.1.0)
     thor (0.18.1)
     thread_safe (0.1.3)
       atomic
@@ -106,3 +107,4 @@ DEPENDENCIES
   pry
   rails!
   sqlite3
+  test-unit

--- a/lib/commentable_methods.rb
+++ b/lib/commentable_methods.rb
@@ -1,18 +1,14 @@
 require 'active_record'
+require 'rails/version'
 
 # ActsAsCommentable
 module Juixe
   module Acts #:nodoc:
     module Commentable #:nodoc:
-
-      def self.included(base)
-        base.extend ClassMethods
-      end
-
       module HelperMethods
         private
         def define_role_based_inflection(role)
-          send("define_role_based_inflection_#{Rails.version.first}", role)
+          send("define_role_based_inflection_#{Rails::VERSION::MAJOR}", role)
         end
 
         def define_role_based_inflection_3(role)
@@ -35,56 +31,54 @@ module Juixe
         end
       end
 
-      module ClassMethods
-        include HelperMethods
+      include HelperMethods
 
-        def acts_as_commentable(*args)
-          options = args.to_a.flatten.compact.partition{ |opt| opt.kind_of? Hash }
-          comment_roles = options.last.blank? ? nil : options.last.flatten.compact.map(&:to_sym)
+      def acts_as_commentable(*args)
+        options = args.to_a.flatten.compact.partition{ |opt| opt.kind_of? Hash }
+        comment_roles = options.last.blank? ? nil : options.last.flatten.compact.map(&:to_sym)
 
-          join_options = options.first.blank? ? [{}] : options.first
-          throw 'Only one set of options can be supplied for the join' if join_options.length > 1
-          join_options = join_options.first
+        join_options = options.first.blank? ? [{}] : options.first
+        throw 'Only one set of options can be supplied for the join' if join_options.length > 1
+        join_options = join_options.first
 
-          class_attribute :comment_types
-          self.comment_types = (comment_roles.blank? ? [:comments] : comment_roles)
+        class_attribute :comment_types
+        self.comment_types = (comment_roles.blank? ? [:comments] : comment_roles)
 
-          if !comment_roles.blank?
-            comment_roles.each do |role|
-              define_role_based_inflection(role)
+        if !comment_roles.blank?
+          comment_roles.each do |role|
+            define_role_based_inflection(role)
+          end
+          has_many :all_comments, { :as => :commentable, :dependent => :destroy, class_name: 'Comment' }.merge(join_options)
+        else
+          has_many :comments, {:as => :commentable, :dependent => :destroy}.merge(join_options)
+        end
+
+        comment_types.each do |role|
+          method_name = (role == :comments ? "comments" : "#{role.to_s}_comments").to_s
+          class_eval %{
+            def self.find_#{method_name}_for(obj)
+              commentable = self.base_class.name
+              Comment.find_comments_for_commentable(commentable, obj.id, "#{role.to_s}")
             end
-            has_many :all_comments, { :as => :commentable, :dependent => :destroy, class_name: 'Comment' }.merge(join_options)
-          else
-            has_many :comments, {:as => :commentable, :dependent => :destroy}.merge(join_options)
-          end
 
-          comment_types.each do |role|
-            method_name = (role == :comments ? "comments" : "#{role.to_s}_comments").to_s
-            class_eval %{
-              def self.find_#{method_name}_for(obj)
-                commentable = self.base_class.name
-                Comment.find_comments_for_commentable(commentable, obj.id, "#{role.to_s}")
-              end
+            def self.find_#{method_name}_by_user(user)
+              commentable = self.base_class.name
+              Comment.where(["user_id = ? and commentable_type = ? and role = ?", user.id, commentable, "#{role.to_s}"]).order("created_at DESC")
+            end
 
-              def self.find_#{method_name}_by_user(user)
-                commentable = self.base_class.name
-                Comment.where(["user_id = ? and commentable_type = ? and role = ?", user.id, commentable, "#{role.to_s}"]).order("created_at DESC")
-              end
+            def #{method_name}_ordered_by_submitted
+              Comment.find_comments_for_commentable(self.class.name, id, "#{role.to_s}").order("created_at")
+            end
 
-              def #{method_name}_ordered_by_submitted
-                Comment.find_comments_for_commentable(self.class.name, id, "#{role.to_s}").order("created_at")
-              end
-
-              def add_#{method_name.singularize}(comment)
-                comment.role = "#{role.to_s}"
-                #{method_name} << comment
-              end
-            }
-          end
+            def add_#{method_name.singularize}(comment)
+              comment.role = "#{role.to_s}"
+              #{method_name} << comment
+            end
+          }
         end
       end
     end
   end
 end
 
-ActiveRecord::Base.send(:include, Juixe::Acts::Commentable)
+ActiveRecord::Base.send(:extend, Juixe::Acts::Commentable)


### PR DESCRIPTION
Just a small tidy up that I thought I'd pass on. Juixe::Acts::Commentable was being included in AR::Base with a ClassMethods module, and this ClassMethods module was being extended on AR::Base when the Commentable module was included:

``` ruby
module Commentable
  def self.included(base)
    base.extend(ClassMethods)
  end

  module ClassMethods
    # ...
  end
end

ActiveRecord::Base.send(:include, Commentable)
```

This is unnecessary indirection because you can just extend the module in the first place and do away with the ClassMethods module and the self.included method, a la:

``` ruby
module Commentable
  # ...
end

ActiveRecord::Base.send(:extend, Commentable)
```

I also couldn't get the test suite running with Ruby 2.1.1 out of the box, so I've included what was necessary for me to get the suite green, which was:
- Add test-unit to development gems
- Change Rails.version.first to Rails::VERSION::MAJOR because String#first is a ActiveSupport extension
- Added require 'rails/version' to be able to get Rails::VERSION ...
