### PR TITLE
Adds role based inflection method for rails5

### DIFF
--- a/lib/commentable_methods.rb
+++ b/lib/commentable_methods.rb
@@ -26,6 +26,12 @@ module Juixe
                    has_many_options(role)
         end
 
+        def define_role_based_inflection_5(role)
+          has_many "#{role.to_s}_comments".to_sym,
+                   -> { where(role: role.to_s) },
+                   has_many_options(role)
+        end
+
         def has_many_options(role)
           {:class_name => "Comment",
                   :as => :commentable,


### PR DESCRIPTION
Basically just added 

```
        def define_role_based_inflection_5(role)
          has_many "#{role.to_s}_comments".to_sym,
                   -> { where(role: role.to_s) },
                   has_many_options(role)
        end
```

For rails5 compatibility
