### PR TITLE
Fix Ruby 2.7 keyword parameters deprecation warning

### DIFF
--- a/lib/commentable_methods.rb
+++ b/lib/commentable_methods.rb
@@ -17,13 +17,13 @@ module Juixe
 
         def define_role_based_inflection_3(role)
           has_many "#{role.to_s}_comments".to_sym,
-                   has_many_options(role).merge(:conditions => { role: role.to_s })
+                   **has_many_options(role).merge(:conditions => { role: role.to_s })
         end
 
         def define_role_based_inflection_4(role)
           has_many "#{role.to_s}_comments".to_sym,
                    -> { where(role: role.to_s) },
-                   has_many_options(role)
+                   **has_many_options(role)
         end
 
         def has_many_options(role)
@@ -53,9 +53,9 @@ module Juixe
             comment_roles.each do |role|
               define_role_based_inflection(role)
             end
-            has_many :all_comments, { :as => :commentable, :dependent => :destroy, class_name: 'Comment' }.merge(join_options)
+            has_many :all_comments, **{ :as => :commentable, :dependent => :destroy, class_name: 'Comment' }.merge(join_options)
           else
-            has_many :comments, {:as => :commentable, :dependent => :destroy}.merge(join_options)
+            has_many :comments, **{:as => :commentable, :dependent => :destroy}.merge(join_options)
           end
 
           comment_types.each do |role|


### PR DESCRIPTION
This fixes the following warnings that are printed when using this gem with Ruby 2.7.:

```
/home/ubuntu/foo/vendor/bundle/ruby/2.7.0/gems/acts_as_commentable-4.0.2/lib/commentable_methods.rb:58: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/home/ubuntu/foo/vendor/bundle/ruby/2.7.0/gems/activerecord-6.0.3.1/lib/active_record/associations.rb:1370: warning: The called method `has_many' is defined here
```